### PR TITLE
fix extension

### DIFF
--- a/src/Style.ts
+++ b/src/Style.ts
@@ -1,6 +1,5 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as vscode from "vscode";
 import Config from "./Config";
 import { stringify } from "querystring";
 
@@ -67,12 +66,17 @@ class Style {
       size = Config.GetConfig("size");
     }
 
-    imagesJs = ('"' + path + '"').replace(/\\/g, "/");
+    /* fix provided by Katsute <https://github.com/Katsute> */ {
+        const isGIF: boolean = path.endsWith(".gif");
+        const imgAsBase64: string = fs.existsSync(path) ? fs.readFileSync(path, "base64") : "";
+        imagesJs = `data:image/${isGIF ? "gif" : "png"};base64,${imgAsBase64}`;
+    }
+
     return `
 /*${this.extName}-start*/
 /*${this.extName}.ver.${pkg.version}*/
 window.onload = function() {
-    const image = ${imagesJs}
+    const image = "${imagesJs}"
     const defaultOpacity = ${opacity}
     const position = "${pos}"
     const size = "${size}"


### PR DESCRIPTION
This pull implements #9 and fixes #8.

Fixes the issue where VSCode won't allow loading a local background image by:
 - reading the background image file
 - converting it to base64
 - using the base64 value as the new background image URL

The only drawback to this fix is that now the file contains a massive base64 string instead of a simple URL.